### PR TITLE
remove bot token from application.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ nbbuild/
 dist/
 nbdist/
 .nb-gradle/
+
+### BOT TOKEN ###
+/src/main/resources/bot.properties

--- a/src/main/java/org/anstreth/schedulebot/SchedulerBotProvider.java
+++ b/src/main/java/org/anstreth/schedulebot/SchedulerBotProvider.java
@@ -5,9 +5,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @DependsOn("telegramBotsApi")
+@PropertySource("classpath:bot.properties")
 class SchedulerBotProvider {
 
     @Value("${bot.token}")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,3 @@
-bot.token = 202940406:AAGSe4Ep5y5vcrgN1Ug6w511TVKOiSoOaxQ
 my_group.id = 21811
 
 ruzapi.weekschedule = http://ruz2.spbstu.ru/api/v1/ruz/scheduler/{group_id}?date={date}


### PR DESCRIPTION
For security reasons `bot_token` was removed from **application.properties**.
In order to make bot work again, you need to create a separate **bot.properties** file and place your valid `bot_token` there. The code is already configured to work with the **bot.properties** file.